### PR TITLE
Display all object masks instead of only the first

### DIFF
--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -168,7 +168,9 @@ def draw_masks(draw, objects, obj_categories, ignore, alpha):
             fill = tuple(list(c[-1]) + [alpha])
             # Polygonal masks work fine
             if isinstance(m, list):
-                draw.polygon(m[0], outline=fill, fill=fill)
+                for m_ in m:
+                    if m_:
+                        draw.polygon(m_, outline=fill, fill=fill)
             # TODO: Fix problem with RLE
             # elif isinstance(m, dict):
             #     draw.polygon(m['counts'][1:-2], outline=c[-1], fill=fill)


### PR DESCRIPTION
First of all thank you for your work, very useful for custom datasets!

- Before the fix, only the first mask for any object is displayed (see the person on the left)


![before_fix_first_mask_only](https://user-images.githubusercontent.com/12609780/107782003-d7c4bd80-6d48-11eb-8d82-e36696ca8d3d.png)

- After, all the masks are displayed


![after_fix_all_masks](https://user-images.githubusercontent.com/12609780/107782021-de533500-6d48-11eb-9d1c-a609e3b3a340.png)
