### PR TITLE
Support rotation

### DIFF
--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -207,37 +207,38 @@ def draw_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size
 
 def draw_rotated_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size):
     for i, (c, obj) in enumerate(zip(obj_categories, objects)):
-        x = int(obj['bbox'][0])
-        y = int(obj['bbox'][1])
-        box_width = int(obj['bbox'][2])
-        box_height = int(obj['bbox'][3])
-        box = [x, y, x+box_width, y+box_height]
+        if i not in ignore:
+            x = int(obj['bbox'][0])
+            y = int(obj['bbox'][1])
+            box_width = int(obj['bbox'][2])
+            box_height = int(obj['bbox'][3])
+            box = [x, y, x+box_width, y+box_height]
 
-        rotation = obj['attributes']['rotation']
+            rotation = obj['attributes']['rotation']
 
-        points = [(int(x), int(y)),
-                  (int(x + box_width), int(y)),
-                  (int(x + box_width), int(y + box_height)),
-                  (int(x), int(y + box_height))]
+            points = [(int(x), int(y)),
+                      (int(x + box_width), int(y)),
+                      (int(x + box_width), int(y + box_height)),
+                      (int(x), int(y + box_height))]
 
-        center_point = (int(x + box_width / 2), int(y + box_height / 2))
+            center_point = (int(x + box_width / 2), int(y + box_height / 2))
 
-        angle_rad = rotation * (3.14159 / 180)
-        rotated_points = []
+            angle_rad = rotation * (3.14159 / 180)
+            rotated_points = []
 
-        for point in points:
-            translated_x = point[0] - center_point[0]
-            translated_y = point[1] - center_point[1]
-            rotated_x = translated_x * math.cos(angle_rad) - translated_y * math.sin(angle_rad)
-            rotated_y = translated_x * math.sin(angle_rad) + translated_y * math.cos(angle_rad)
-            final_x = rotated_x + center_point[0]
-            final_y = rotated_y + center_point[1]
-            rotated_points.append((final_x, final_y))
+            for point in points:
+                translated_x = point[0] - center_point[0]
+                translated_y = point[1] - center_point[1]
+                rotated_x = translated_x * math.cos(angle_rad) - translated_y * math.sin(angle_rad)
+                rotated_y = translated_x * math.sin(angle_rad) + translated_y * math.cos(angle_rad)
+                final_x = rotated_x + center_point[0]
+                final_y = rotated_y + center_point[1]
+                rotated_points.append((final_x, final_y))
 
-        draw.polygon(rotated_points, outline=c[-1], width=width)
+            draw.polygon(rotated_points, outline=c[-1], width=width)
 
-        if labels:
-            show_label(label_size, c, box, draw)
+            if labels:
+                show_label(label_size, c, box, draw)
 
 
 def draw_masks(draw, objects, obj_categories, ignore, alpha):

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -200,6 +200,44 @@ def draw_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size
                 draw.text((tx0, ty0), text, (255, 255, 255), font=font)
 
 
+def draw_rotated_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size):
+    for i, (c, obj) in enumerate(zip(obj_categories, objects)):
+        print('obj', obj)
+        if 'attributes' in obj.keys():
+            if obj['attributes']['rotation'] != 0:
+
+                x = int(obj['bbox'][0])
+                y = int(obj['bbox'][1])
+                box_width = int(obj['bbox'][2])
+                box_height = int(obj['bbox'][3])
+                rotation = obj['attributes']['rotation']
+
+
+                points = [(int(x), int(y)),
+                          (int(x + box_width), int(y)),
+                          (int(x + box_width), int(y + box_height)),
+                          (int(x), int(y + box_height))]
+
+                center_point = (int(x + box_width / 2), int(y + box_height / 2))
+
+                angle_rad = rotation * (3.14159 / 180)
+                center_x, center_y = center_point
+                rotated_points = []
+                import math
+                for point in points:
+                    translated_x = point[0] - center_x
+                    translated_y = point[1] - center_y
+                    rotated_x = translated_x * math.cos(angle_rad) - translated_y * math.sin(angle_rad)
+                    rotated_y = translated_x * math.sin(angle_rad) + translated_y * math.cos(angle_rad)
+                    final_x = rotated_x + center_x
+                    final_y = rotated_y + center_y
+                    rotated_points.append((final_x, final_y))
+
+                draw.polygon(rotated_points, outline="red", width=width)
+
+                break
+
+
 def draw_masks(draw, objects, obj_categories, ignore, alpha):
     """Draws a masks over image."""
     masks = [obj["segmentation"] for obj in objects]
@@ -616,7 +654,8 @@ class Controller:
             draw_masks(draw, objects, names_colors, ignore, alpha)
         # Draw bounding boxes
         if bboxes_on:
-            draw_bboxes(draw, objects, labels_on, names_colors, ignore, width, label_size)
+            # draw_bboxes(draw, objects, labels_on, names_colors, ignore, width, label_size)
+            draw_rotated_bboxes(draw, objects, labels_on, names_colors, ignore, width, label_size)
         del draw
         # Resulting image
         self.current_composed_image = Image.alpha_composite(img_open, draw_layer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+cffi~=1.15.1
+future~=0.18.3
+Pillow~=9.0.1
+pip~=22.0.4
+wheel~=0.37.1
+cryptography~=3.4.8
+numpy~=1.21.6
+setuptools~=59.6.0
+certifi~=2020.6.20
+pycparser~=2.21


### PR DESCRIPTION
HI! I added the functionality of drawing rotated frames
to test it you need to add appropriate keys to the annotated json file. 
   `"attributes": {
        "occluded": false,
        "rotation": 60
      }`

Example:
`{
      "id": 1,
      "image_id": 1,
      "category_id": 1,
      "segmentation": [],
      "area": 1721.5952,
      "bbox": [
        282.86,
        459.49,
        89.48,
        19.24
      ],
      "iscrowd": 0,
      "attributes": {
        "occluded": false,
        "rotation": 318.30000076003773
      }`

I added requirements.txt file too, I don't know if it will come in handy