### PR TITLE
[MOD] RLE-String Decode

### DIFF
--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -225,14 +225,44 @@ def draw_masks(draw, objects, obj_categories, ignore, alpha):
 
 def rle_to_mask(rle, height, width):
     rows, cols = height, width
-    rle_pairs = np.array(rle).reshape(-1, 2)
     img = np.zeros(rows * cols, dtype=np.uint8)
     index_offset = 0
+    
+    if type(rle) == str:
+        m = 0
+        p = 0
+        k = 0
+        str_len = len(rle)
+        cnts= [0] * str_len
+        while p < str_len:
+            x=0
+            k=0
+            more=1
+            while more != 0 :
+                c= ord(rle[p]) - 48
+                x |= ((c & 0x1f) << (5*k))
+                more = c & 0x20
+                p+=1
+                k+=1
+                if p >= str_len-1:
+                    break
+                if more == 0 and (c & 0x10 != 0): 
+                    x |= -1 << 5*k
+     
+            if(m>2) :
+                x += cnts[m-2]
+            cnts[m]=x
 
-    for index, length in rle_pairs:
-        index_offset += index
-        img[index_offset : index_offset + length] = 255
-        index_offset += length
+            if m%2 == 1:
+                img[index_offset : index_offset + x] = 255
+            index_offset+=x
+            m+=1
+    else:
+        rle_pairs = np.array(rle).reshape(-1, 2)
+        for index, length in rle_pairs:
+            index_offset += index
+            img[index_offset : index_offset + length] = 255
+            index_offset += length
 
     img = img.reshape(cols, rows)
     img = img.T


### PR DESCRIPTION
## RLE-String Decode
- I test my coco file for both kind of RLE format: string or pure number
-  Here is the test result, fits well:
[test.zip](https://github.com/trsvchn/coco-viewer/files/13542911/test.zip)

- The segment using string format:
![segment-string](https://github.com/trsvchn/coco-viewer/assets/16344694/33965386-4834-4bab-ad2c-46c39420ba89)

- This pr will handle that kind of string data above:
![result](https://github.com/trsvchn/coco-viewer/assets/16344694/e80e3d9e-a53e-438c-bb1f-ff111dfe2f40)

- The addtional code is copied from the original [cocoapi](https://github.com/cocodataset/cocoapi/blob/master/common/maskApi.c)

