### PR TITLE
Replace pillow's deprecated textsize, add zooming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Simple COCO Objects Viewer in Tkinter. Allows quick viewing on local machine.
 | <kbd>M</kbd>, <kbd>Ctrl</kbd> + <kbd>M</kbd> | Toggle **M**asks |
 | <kbd>Ctrl</kbd> + <kbd>S</kbd> | Save Current Image |
 | <kbd>Ctrl</kbd> + <kbd>Q</kbd>, <kbd>Ctrl</kbd> + <kbd>W</kbd> | Exit Viewer |
+| <kbd>Ctrl</kbd> + <kbd>+</kbd> | Zoom In |
+| <kbd>Ctrl</kbd> + <kbd>-</kbd> | Zoom Out |
 
 ## Requirements
 `python3` `PIL`

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -180,9 +180,9 @@ def draw_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size
                     # TODO: Implement notification message as popup window
                     font = ImageFont.load_default()
 
-                left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+                _, _, tw, th = draw.textbbox((0, 0), text, font=font)
                 _, descent = font.getmetrics()
-                tw, th = right - left, bottom - top + descent
+                th += descent
                 tx0 = b[0]
                 ty0 = b[1] - th
 

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -550,6 +550,8 @@ class Controller:
         self.menu.view.entryconfigure("BBoxes", variable=self.bboxes_on_global, command=self.menu_view_bboxes)
         self.menu.view.entryconfigure("Labels", variable=self.labels_on_global, command=self.menu_view_labels)
         self.menu.view.entryconfigure("Masks", variable=self.masks_on_global, command=self.menu_view_masks)
+        self.menu.view.entryconfigure("Zoom In", command=self.zoom_in)
+        self.menu.view.entryconfigure("Zoom Out", command=self.zoom_out)
         self.menu.view.colormenu.entryconfigure(
             "Categories",
             variable=self.coloring_on_global,
@@ -853,11 +855,11 @@ class Controller:
     def masks_slider_status_update(self):
         self.sliders.mask_slider.configure(state=tk.NORMAL if self.masks_on_local else tk.DISABLED)
 
-    def zoom_in(self, event):
+    def zoom_in(self, event=None):
         self.zoom_factor *= self.ZOOM_STEP
         self.update_img(local=False)
 
-    def zoom_out(self, event):
+    def zoom_out(self, event=None):
         self.zoom_factor /= self.ZOOM_STEP
         self.update_img(local=False)
 

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -180,9 +180,8 @@ def draw_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size
                     # TODO: Implement notification message as popup window
                     font = ImageFont.load_default()
 
-                tw, th = draw.textsize(text, font)
-                tx0 = b[0]
-                ty0 = b[1] - th
+                left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+                tw, th = right - left, bottom - top
 
                 # TODO: Looks weird! We need image dims to make it right
                 tx0 = max(b[0], max(b[0], tx0)) if tx0 < 0 else tx0

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -181,10 +181,10 @@ def draw_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size
                     font = ImageFont.load_default()
 
                 left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
-                tw, th = right - left, bottom - top
-                # Add space below the baseline
                 _, descent = font.getmetrics()
-                th += descent
+                tw, th = right - left, bottom - top + descent
+                tx0 = b[0]
+                ty0 = b[1] - th
 
                 # TODO: Looks weird! We need image dims to make it right
                 tx0 = max(b[0], max(b[0], tx0)) if tx0 < 0 else tx0

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -873,18 +873,31 @@ def print_info(message: str):
     logging.info(message)
 
 
+def exit_with_error(message: str, root=None):
+    root.geometry("300x150")  # app size when no data is provided
+    messagebox.showwarning("Warning!", message)
+    print_info("Exiting because of error: " + message)
+    root.destroy()
+    exit(1)
+
+
 def main():
     print_info("Starting...")
     args = parser.parse_args()
     root = tk.Tk()
     root.title("COCO Viewer")
 
-    if not args.images or not args.annotations:
-        root.geometry("300x150")  # app size when no data is provided
-        messagebox.showwarning("Warning!", "Nothing to show.\nPlease specify a path to the COCO dataset!")
-        print_info("Exiting...")
-        root.destroy()
-        return
+    if not args.annotations:
+        exit_with_error("No annotations file provided!", root)
+    elif not os.path.exists(args.annotations) or not os.path.isfile(args.annotations):
+        exit_with_error("Invalid annotations file path!", root)
+    elif not args.images:
+        try:
+            # Use image root from the annotations file if not provided via command line
+            args.images = json.loads(open(args.annotations).read())["image_root"]
+        except KeyError:
+            exit_with_error("No images folder provided neither via the annotations file "
+                            "nor as a command line argument!", root)
 
     data = Data(args.images, args.annotations)
     statusbar = StatusBar(root)

--- a/cocoviewer.py
+++ b/cocoviewer.py
@@ -182,6 +182,9 @@ def draw_bboxes(draw, objects, labels, obj_categories, ignore, width, label_size
 
                 left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
                 tw, th = right - left, bottom - top
+                # Add space below the baseline
+                _, descent = font.getmetrics()
+                th += descent
 
                 # TODO: Looks weird! We need image dims to make it right
                 tx0 = max(b[0], max(b[0], tx0)) if tx0 < 0 else tx0


### PR DESCRIPTION
- Use `getbboxsize` instead of the deprecated `textsize` [critical fix, closes #74]
- Use COCO format's `image_root`, if available, when not provided via command line [feature]
- Allow to zoom images in/out using `Ctrl`+`+` or `Ctrl`+`-` [feature, closes #53]